### PR TITLE
fix slices.Grow usage

### DIFF
--- a/dynamicpool.go
+++ b/dynamicpool.go
@@ -3,7 +3,6 @@ package bytepool
 // originally from https://github.com/valyala/bytebufferpool/blob/master/pool.go
 
 import (
-	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -49,7 +48,7 @@ func (p *dynamicPool) Get() *Bytes {
 
 func (p *dynamicPool) GetGrown(c int) *Bytes {
 	b := p.Get()
-	b.B = slices.Grow(b.B, c)
+	b.B = grow(b.B, c)
 	return b
 }
 

--- a/pool.go
+++ b/pool.go
@@ -24,3 +24,16 @@ type Pooler interface {
 
 	SizedPooler
 }
+
+// Similar to slices.Grow, but ensures capacity for n total (not just additional appended) elements.
+func grow(s []byte, n int) []byte {
+	if n < 0 {
+		panic("bytepool: n arg to grow cannot be negative")
+	}
+	need := n - cap(s)
+	if need <= 0 {
+		return s
+	}
+	// slices.Grow says: This expression allocates only once (see test).
+	return append(s[:cap(s)], make([]byte, need)...)[:len(s)]
+}

--- a/sync.go
+++ b/sync.go
@@ -1,7 +1,6 @@
 package bytepool
 
 import (
-	"slices"
 	"sync"
 )
 
@@ -26,7 +25,7 @@ func (p *syncPool) Get() *Bytes {
 
 func (p *syncPool) GetGrown(c int) *Bytes {
 	b := p.Get()
-	b.B = slices.Grow(b.B, c)
+	b.B = grow(b.B, c)
 	return b
 }
 


### PR DESCRIPTION
See comment on new grow() func. We would have been potentially over allocating.