### PR TITLE
fix bucket choice

### DIFF
--- a/bucketpool_test.go
+++ b/bucketpool_test.go
@@ -327,7 +327,8 @@ func TestBucket_fuzz(t *testing.T) {
 
 func BenchmarkBucket_getPut(b *testing.B) {
 	const maxSize = 16384
-	pool := bytepool.NewBucket(2, maxSize)
+	pool := bytepool.NewBucketExpo(2, maxSize, 30)
+	b.Log("buckets", len(pool.Buckets()))
 	b.SetParallelism(16)
 	b.RunParallel(func(pb *testing.PB) {
 		rando := rand.New(rand.NewPCG(0, 0))
@@ -342,7 +343,8 @@ func BenchmarkBucket_getPut(b *testing.B) {
 
 func BenchmarkBucket_get(b *testing.B) {
 	const maxSize = 16384
-	pool := bytepool.NewBucket(2, maxSize)
+	pool := bytepool.NewBucketExpo(2, maxSize, 30)
+	b.Log("buckets", len(pool.Buckets()))
 	b.SetParallelism(16)
 	b.RunParallel(func(pb *testing.PB) {
 		rando := rand.New(rand.NewPCG(0, 0))

--- a/pool_test.go
+++ b/pool_test.go
@@ -54,8 +54,11 @@ func TestSizedPooler_concurrentMutation(t *testing.T) {
 	t.Run("dynamic", func(t *testing.T) {
 		run(t, bytepool.NewDynamic())
 	})
-	t.Run("bucket", func(t *testing.T) {
+	t.Run("bucket_norm", func(t *testing.T) {
 		run(t, bytepool.NewBucket(1, 20))
+	})
+	t.Run("bucket_expo", func(t *testing.T) {
+		run(t, bytepool.NewBucketExpo(1, 20, 20))
 	})
 }
 
@@ -92,8 +95,11 @@ func TestSizedPooler_lenAndCap(t *testing.T) {
 	t.Run("dynamic", func(t *testing.T) {
 		run(t, bytepool.NewDynamic())
 	})
-	t.Run("bucket", func(t *testing.T) {
+	t.Run("bucket_norm", func(t *testing.T) {
 		run(t, bytepool.NewBucket(1, 20))
+	})
+	t.Run("bucket_expo", func(t *testing.T) {
+		run(t, bytepool.NewBucketExpo(1, 20, 20))
 	})
 }
 


### PR DESCRIPTION
Existing benchmarks on main are around:
```
BenchmarkBucket_getPut
BenchmarkBucket_getPut-8   	56571962	        42.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkBucket_get
BenchmarkBucket_get-8      	 1000000	      2098 ns/op	   11034 B/op	       2 allocs/op
```
and updating just the findPool func to be the loop is basically the same:
```
BenchmarkBucket_getPut
    bucketpool_test.go:332: buckets 14
    bucketpool_test.go:332: buckets 14
    bucketpool_test.go:332: buckets 14
    bucketpool_test.go:332: buckets 14
    bucketpool_test.go:332: buckets 14
BenchmarkBucket_getPut-8   	53288692	        37.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkBucket_get
    bucketpool_test.go:349: buckets 14
    bucketpool_test.go:349: buckets 14
    bucketpool_test.go:349: buckets 14
    bucketpool_test.go:349: buckets 14
    bucketpool_test.go:349: buckets 14
BenchmarkBucket_get-8      	 1132190	      2123 ns/op	   11009 B/op	       2 allocs/op
```
changing the two benches then to expo with 30 buckets looks like:
```
BenchmarkBucket_getPut
    bucketpool_test.go:331: buckets 30
    bucketpool_test.go:331: buckets 30
    bucketpool_test.go:331: buckets 30
    bucketpool_test.go:331: buckets 30
    bucketpool_test.go:331: buckets 30
    bucketpool_test.go:331: buckets 30
BenchmarkBucket_getPut-8   	63062420	        37.96 ns/op	       0 B/op	       0 allocs/op
BenchmarkBucket_get
    bucketpool_test.go:347: buckets 30
    bucketpool_test.go:347: buckets 30
    bucketpool_test.go:347: buckets 30
    bucketpool_test.go:347: buckets 30
BenchmarkBucket_get-8      	 1000000	      2264 ns/op	    9788 B/op	       2 allocs/op
```
and of course the more buckets you add the slower it will get, but still fast enough. For example here is 500 buckets configured (369 actual):
```
BenchmarkBucket_getPut
    bucketpool_test.go:331: buckets 369
    bucketpool_test.go:331: buckets 369
    bucketpool_test.go:331: buckets 369
    bucketpool_test.go:331: buckets 369
    bucketpool_test.go:331: buckets 369
BenchmarkBucket_getPut-8   	31697138	        68.56 ns/op	       0 B/op	       0 allocs/op
BenchmarkBucket_get
    bucketpool_test.go:347: buckets 369
    bucketpool_test.go:347: buckets 369
    bucketpool_test.go:347: buckets 369
    bucketpool_test.go:347: buckets 369
BenchmarkBucket_get-8      	  979215	      3300 ns/op	    9338 B/op	       2 allocs/op
```