### PR TITLE
always alloc to size

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -44,3 +44,14 @@ func Grow[T any](s []T, min int) []T {
 	// allocates only once, shown in the tests. Similar to slices.Grow (note it isn't for min total).
 	return append(s[:cap(s)], make([]T, min-c)...)[:0]
 }
+
+// Returns s if cap(s) >= size, otherwise makes a new slice with cap=size.
+// New slice does not preserve contents of s.
+// Size can be <= 0.
+// Returned slice has len=0.
+func Sized[T any](s []T, size int) []T {
+	if size <= cap(s) {
+		return s[:0]
+	}
+	return make([]T, 0, size)
+}


### PR DESCRIPTION
Currently, calling GetGrown(X) will return a slice of cap=X if it
allocates anew. Later, if that same slice is used by a GetGrown(Y)
call, it may need to be grown to fit Y.

That can cause a lot of extra copying and allocation.

To help that, have GetGrown/GetFilled always alloc to the relevant
bucket size. If GetGrown(X) and GetGrown(Y) are served by the same
bucket the slices they return will have cap equal to that bucket's
size.
